### PR TITLE
new "pruned" view

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -28,6 +28,7 @@ var homeController = require('./controllers/home');
 var userController = require('./controllers/user');
 var adminController = require('./controllers/admin');
 var tagController = require('./controllers/tag');
+var prunedController = require('./controllers/pruned');
 
 /**
  * API keys and Passport configuration.
@@ -112,6 +113,7 @@ app.get('/SPO2Count', passportConf.isAuthenticated, homeController.SPO2Count);
 app.get('/status', passportConf.isAuthenticated, homeController.status);
 app.get('/historical', passportConf.isAuthenticated, homeController.historical);
 app.get('/tags', passportConf.isAuthenticated, homeController.tags);
+app.get('/pruned', passportConf.isAuthenticated, homeController.pruned);
 app.get('/pushdeviceadd/:deviceToken', homeController.addDevice)
 app.get('/pushnotification/:message', homeController.pushNotification)
 

--- a/app/app.js
+++ b/app/app.js
@@ -28,7 +28,7 @@ var homeController = require('./controllers/home');
 var userController = require('./controllers/user');
 var adminController = require('./controllers/admin');
 var tagController = require('./controllers/tag');
-
+var prunedController = require('./controllers/pruned');
 
 /**
  * API keys and Passport configuration.
@@ -116,6 +116,12 @@ app.get('/tags', passportConf.isAuthenticated, homeController.tags);
 app.get('/pruned', passportConf.isAuthenticated, homeController.pruned);
 app.get('/pushdeviceadd/:deviceToken', homeController.addDevice)
 app.get('/pushnotification/:message', homeController.pushNotification)
+
+/*
+Pruned App routs
+*/
+app.get('/SPO2Data', passportConf.isAuthenticated, prunedController.SPO2Data);
+
 
 /*
 Admin App routs

--- a/app/app.js
+++ b/app/app.js
@@ -28,7 +28,7 @@ var homeController = require('./controllers/home');
 var userController = require('./controllers/user');
 var adminController = require('./controllers/admin');
 var tagController = require('./controllers/tag');
-var prunedController = require('./controllers/pruned');
+
 
 /**
  * API keys and Passport configuration.

--- a/app/app.js
+++ b/app/app.js
@@ -45,10 +45,14 @@ var app = express();
 /**
  * Connect to MongoDB.
  */
-mongoose.connect(secrets.db);
+mongoose.connect(secrets.db, {server:{auto_reconnect:true}});
 mongoose.connection.on('error', function() {
   console.log('MongoDB Connection Error. Please make sure that MongoDB is running.');
-  process.exit(1);
+  mongoose.disconnect();
+});
+mongoose.connection.on('disconnected', function() {
+    console.log('MongoDB disconnected!');
+    mongoose.connect(secrets.db, {server:{auto_reconnect:true}});
 });
 
 /**

--- a/app/app.js
+++ b/app/app.js
@@ -45,14 +45,21 @@ var app = express();
 /**
  * Connect to MongoDB.
  */
-mongoose.connect(secrets.db, {server:{auto_reconnect:true}});
+
+
+
+mongoose.connect(secrets.db, {server: { socketOptions: { connectTimeoutMS: 8000}},auto_reconnect:true });
+
+
+
 mongoose.connection.on('error', function() {
   console.log('MongoDB Connection Error. Please make sure that MongoDB is running.');
   mongoose.disconnect();
 });
 mongoose.connection.on('disconnected', function() {
     console.log('MongoDB disconnected!');
-    mongoose.connect(secrets.db, {server:{auto_reconnect:true}});
+    mongoose.connect(secrets.db, {server: { socketOptions: { connectTimeoutMS: 8000}},auto_reconnect:true});
+
 });
 
 /**

--- a/app/config/settings.js
+++ b/app/config/settings.js
@@ -3,14 +3,15 @@ module.exports = {
 
   theme: {
     babyname: "Baby",
-    
+
   },
 
   newuserpermissions:{
     admin: true,
     history: true,
     live: true,
-    tags: true
+    tags: true,
+    pruned: true
   }
 
 };

--- a/app/controllers/admin.js
+++ b/app/controllers/admin.js
@@ -48,6 +48,10 @@ exports.updateRights = function(req, res){
         user.tags = true;
     else if (req.params.role == "tags" && req.params.state == "false")
         user.tags = false;
+    if (req.params.role == "pruned" && req.params.state == "true")
+        user.pruned = true;
+    else if (req.params.role == "pruned" && req.params.state == "false")
+        user.pruned = false;
 
     user.save(function(err) {
 

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -216,12 +216,12 @@ exports.historicalSPO2Data = function (req, res) {
                     {
                         $group: {
                             _id: {
-                                second: { $second: "$date" },
-                                minute: { $minute: "$date" },
-                                hour: { $hour: "$date" },
+                                year: { $year: "$date" },
                                 month: { $month: "$date" },
                                 day: { $dayOfMonth: "$date" },
-                                year: { $year: "$date" },
+                                hour: { $hour: "$date" },
+                                minute: { $minute: "$date" },
+                                second: { $second: "$date" },
                                 alarm: "$alarm"
                             },
                             value: { $avg: "$spo2" },
@@ -231,7 +231,9 @@ exports.historicalSPO2Data = function (req, res) {
                             min: { $min: "$spo2" },
                             max: { $max: "$spo2" }
                         },
-                    }]
+                    }
+                    , { $sort : { _id : 1 } }
+                  ]
 
                 , function (err, docs) {
                     if (err) console.trace(err)
@@ -255,11 +257,11 @@ exports.historicalSPO2Data = function (req, res) {
                     {
                         $group: {
                             _id: {
-                                minute: { $minute: "$date" },
-                                hour: { $hour: "$date" },
+                                year: { $year: "$date" },
                                 month: { $month: "$date" },
                                 day: { $dayOfMonth: "$date" },
-                                year: { $year: "$date" },
+                                hour: { $hour: "$date" },
+                                minute: { $minute: "$date" },
                                 alarm: "$alarm"
                             },
                             value: { $avg: "$spo2" },
@@ -268,7 +270,9 @@ exports.historicalSPO2Data = function (req, res) {
                             min: { $min: "$spo2" },
                             max: { $max: "$spo2" }
                         },
-                    }]
+                    }
+                    , { $sort : { _id : 1 } }
+                  ]
 
                 , function (err, docs) {
                     if (err) console.trace(err)
@@ -284,10 +288,10 @@ exports.historicalSPO2Data = function (req, res) {
                 {
                     $group: {
                         _id: {
-                            hour: { $hour: "$date" },
+                            year: { $year: "$date" },
                             month: { $month: "$date" },
                             day: { $dayOfMonth: "$date" },
-                            year: { $year: "$date" },
+                            hour: { $hour: "$date" },
                             alarm: "$alarm"
                         },
                         value: { $avg: "$spo2" },
@@ -296,8 +300,9 @@ exports.historicalSPO2Data = function (req, res) {
                         min: { $min: "$spo2" },
                         max: { $max: "$spo2" }
                     },
-                }]
-
+                }
+                    , { $sort : { _id : 1 } }
+                  ]
             , function (err, docs) {
                 if (err) console.trace(err)
                 RenderData(docs, res);

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -40,6 +40,15 @@ exports.tags = function (req, res) {
         title: 'Tags'
     });
 };
+/**
+ * GET /pruned
+ * Adding pruned Page
+ */
+exports.pruned = function (req, res) {
+    res.render('pruned', {
+        title: 'Pruned'
+    });
+};
 
 
 /**

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -172,7 +172,8 @@ exports.SPO2Count = function (req, res) {
                     }]
 
                 , function (err, docs) {
-
+                 if (err)  {console.trace(err) }
+                 else {
                     var total = 0;
                     var results = [];
                      //For each Document Return Added it to either the SPO2 Graph resutls or the Alarm Results.
@@ -188,6 +189,7 @@ exports.SPO2Count = function (req, res) {
                     });
                     results = results.sort(namesort);
                     res.send(results);
+                  }
                 });
     }
 }
@@ -244,7 +246,7 @@ exports.historicalSPO2Data = function (req, res) {
 
                 , function (err, docs) {
                     if (err) console.trace(err)
-                    RenderData(docs, res);
+                    else RenderData(docs, res);
                 });
         } else {
 
@@ -281,7 +283,7 @@ exports.historicalSPO2Data = function (req, res) {
 
                 , function (err, docs) {
                     if (err) console.trace(err)
-                    RenderData(docs, res);
+                    else RenderData(docs, res);
                 });
         }
     } else {
@@ -309,7 +311,7 @@ exports.historicalSPO2Data = function (req, res) {
 
             , function (err, docs) {
                 if (err) console.trace(err)
-                RenderData(docs, res);
+                else RenderData(docs, res);
             });
     }
 };

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -386,6 +386,8 @@ function RenderData(docs, res) {
         //Sort the pi Results.
         pi = sortandnormalize(pi, SkipOffset)
 
+       //Sort the Alarms Results(no normalization )
+        alarms = alarms.sort(timesort);
 
         //Create json object to return.
         var graphData = { alarms: alarms, spo2: results, bpm: bpm, pi: pi };

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -393,7 +393,7 @@ function RenderData(docs, res) {
         //Sort the bpm Results.
         bpm = sortandnormalize(bpm, SkipOffset);
         //Sort the pi Results.
-        pi = sortandnormalize(pi, SkipOffset)
+        pi = sortandnormalize(pi, SkipOffset);
 
        //Sort the Alarms Results(no normalization )
         alarms = alarms.sort(timesort);

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -234,6 +234,7 @@ exports.historicalSPO2Data = function (req, res) {
                     }]
 
                 , function (err, docs) {
+                    if (err) console.trace(err)
                     RenderData(docs, res);
                 });
         } else {
@@ -270,6 +271,7 @@ exports.historicalSPO2Data = function (req, res) {
                     }]
 
                 , function (err, docs) {
+                    if (err) console.trace(err)
                     RenderData(docs, res);
                 });
         }
@@ -297,6 +299,7 @@ exports.historicalSPO2Data = function (req, res) {
                 }]
 
             , function (err, docs) {
+                if (err) console.trace(err)
                 RenderData(docs, res);
             });
     }

--- a/app/controllers/home.js
+++ b/app/controllers/home.js
@@ -216,12 +216,12 @@ exports.historicalSPO2Data = function (req, res) {
                     {
                         $group: {
                             _id: {
-                                year: { $year: "$date" },
+                                second: { $second: "$date" },
+                                minute: { $minute: "$date" },
+                                hour: { $hour: "$date" },
                                 month: { $month: "$date" },
                                 day: { $dayOfMonth: "$date" },
-                                hour: { $hour: "$date" },
-                                minute: { $minute: "$date" },
-                                second: { $second: "$date" },
+                                year: { $year: "$date" },
                                 alarm: "$alarm"
                             },
                             value: { $avg: "$spo2" },
@@ -231,9 +231,7 @@ exports.historicalSPO2Data = function (req, res) {
                             min: { $min: "$spo2" },
                             max: { $max: "$spo2" }
                         },
-                    }
-                    , { $sort : { _id : 1 } }
-                  ]
+                    }]
 
                 , function (err, docs) {
                     if (err) console.trace(err)
@@ -257,11 +255,11 @@ exports.historicalSPO2Data = function (req, res) {
                     {
                         $group: {
                             _id: {
-                                year: { $year: "$date" },
+                                minute: { $minute: "$date" },
+                                hour: { $hour: "$date" },
                                 month: { $month: "$date" },
                                 day: { $dayOfMonth: "$date" },
-                                hour: { $hour: "$date" },
-                                minute: { $minute: "$date" },
+                                year: { $year: "$date" },
                                 alarm: "$alarm"
                             },
                             value: { $avg: "$spo2" },
@@ -270,9 +268,7 @@ exports.historicalSPO2Data = function (req, res) {
                             min: { $min: "$spo2" },
                             max: { $max: "$spo2" }
                         },
-                    }
-                    , { $sort : { _id : 1 } }
-                  ]
+                    }]
 
                 , function (err, docs) {
                     if (err) console.trace(err)
@@ -288,10 +284,10 @@ exports.historicalSPO2Data = function (req, res) {
                 {
                     $group: {
                         _id: {
-                            year: { $year: "$date" },
+                            hour: { $hour: "$date" },
                             month: { $month: "$date" },
                             day: { $dayOfMonth: "$date" },
-                            hour: { $hour: "$date" },
+                            year: { $year: "$date" },
                             alarm: "$alarm"
                         },
                         value: { $avg: "$spo2" },
@@ -300,9 +296,8 @@ exports.historicalSPO2Data = function (req, res) {
                         min: { $min: "$spo2" },
                         max: { $max: "$spo2" }
                     },
-                }
-                    , { $sort : { _id : 1 } }
-                  ]
+                }]
+
             , function (err, docs) {
                 if (err) console.trace(err)
                 RenderData(docs, res);

--- a/app/controllers/pruned.js
+++ b/app/controllers/pruned.js
@@ -1,7 +1,0 @@
-var _ = require('lodash');
-var async = require('async');
-var crypto = require('crypto');
-var nodemailer = require('nodemailer');
-var passport = require('passport');
-
-var RadEvent = require('../models/RADEvent');

--- a/app/controllers/pruned.js
+++ b/app/controllers/pruned.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+var async = require('async');
+var crypto = require('crypto');
+var nodemailer = require('nodemailer');
+var passport = require('passport');
+
+var RadEvent = require('../models/RADEvent');

--- a/app/controllers/pruned.js
+++ b/app/controllers/pruned.js
@@ -41,7 +41,7 @@ exports.SPO2Data = function (req, res) {
               .sort({ date: 1 })
         events.exec(function (err, docs) {
                if (err) console.trace(err)
-               RenderData(docs, res);
+               else RenderData(docs, res);
                 });
 
 

--- a/app/controllers/pruned.js
+++ b/app/controllers/pruned.js
@@ -1,0 +1,153 @@
+var RadEvent = require('../models/RADEvent');
+var Device = require('../models/pushNotificationDevice');
+var settings = require('../config/settings');
+var apn = require('apn')
+
+
+
+/**
+ * GET /SPO2Data
+ * Historical SPO2 Graph Data
+ */
+exports.SPO2Data = function (req, res) {
+    res.setHeader('Content-Type', 'application/json');
+
+    //Group Events by Year/Month/Day/Minute/Alarm
+    //Get the Average of the SPO2 for the group.
+
+        var startMS = parseFloat(req.query.start);
+        var endMS = parseFloat(req.query.end);
+        var start = new Date(startMS);
+        var end = new Date(endMS);
+        var duration = endMS - startMS;
+
+
+        var events = RadEvent.find({
+              spo2: { $ne: -1 },
+           //   pi: {$gte: 1},
+              date: {
+                  $gte: start,
+                  $lte: end
+                    }
+                },
+               {
+                date : 1,
+                spo2:  1,
+                bpm:   1,
+                pi:    1,
+                alarm: 1
+              }
+              )
+              .sort({ date: 1 })
+        events.exec(function (err, docs) {
+               if (err) console.trace(err)
+               RenderData(docs, res);
+                });
+
+
+};
+
+function RenderData(docs, res) {
+
+    //Sucess from Mongo.
+    var results = [];
+    var bpm = [];
+    var pi = [];
+    var alarms = [];
+    var offset = (1000 * 60 * 60 * 8);
+    var SkipOffset = 1000 * 60;
+    if (docs.length > 0) {
+
+
+        //For each Document Return Added it to either the SPO2 Graph resutls or the Alarm Results.
+        docs.forEach(function (element) {
+            var id = element._id;
+
+            if (element.spo2 < 70)
+                element.spo2 = null;
+            //Add to SPO2 results.
+            results.push(
+                {
+                    //Get date and add the timezone offset so that it shows correct on the graph.
+                    x: element.date.getTime(),
+                    y: element.spo2,
+                    low: element.spo2,
+                    high: element.spo2
+                });
+            bpm.push({
+                x: element.date.getTime(),
+                y: element.bpm
+            });
+            pi.push({
+                x:  element.date.getTime(),
+                y: element.pi
+            });
+
+            if (element.spo2 <=88) {
+                //we have an alarm.
+
+                var alarmTitle = "Alarm"
+                //Check to see if the alarm is now silenced. Change Title to reflect.
+                if (id.alarm == "0020") {
+                    alarmTitle = "Alarm Silenced"
+                }
+
+                alarms.push(
+                    {
+                        x:  element.date.getTime(),
+                        y: element.spo2,
+                        o2: element.spo2,
+                        bpm: element.bpm,
+                        pi: element.pi
+                    });
+            }
+
+        }, this);
+
+        //Sort the SPO2 Results.
+  //      results = sortandnormalize(results, SkipOffset);
+        //Sort the bpm Results.
+//        bpm = sortandnormalize(bpm, SkipOffset);
+        //Sort the pi Results.
+    //    pi = sortandnormalize(pi, SkipOffset)
+
+       //Sort the Alarms Results(no normalization )
+  //      alarms = alarms.sort(timesort);
+
+        //Create json object to return.
+        var graphData = { alarms: alarms, spo2: results, bpm: bpm, pi: pi };
+        res.send(graphData);
+    }
+}
+
+function timesort(a, b) {
+    return a.x - b.x;
+}
+function namesort(a, b) {
+    return a.name - b.name;
+}
+
+function sortandnormalize(list, SkipOffset) {
+    list = list.sort(timesort);
+
+    var lastDate = list[0].x;
+    list.forEach(function (element) {
+
+        while ((lastDate + SkipOffset) < element.x) {
+            lastDate = lastDate + SkipOffset;
+            list.push(
+                {
+                    x: lastDate,
+                    y: null,
+                    low: null,
+                    high: null,
+                });
+
+        }
+        list.push(element);
+        lastDate = element.x
+    }, this);
+
+    list = list.sort(timesort);
+    return list;
+}

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -111,6 +111,7 @@ exports.postSignup = function (req, res, next) {
     user.history = settings.newuserpermissions.history;
     user.live = settings.newuserpermissions.live;
     user.tags = settings.newuserpermissions.tags;
+    user.pruned = settings.newuserpermissions.pruned;
     user.lastLogin = new Date().toString();
     user.save(function (err) {
       if (err) {

--- a/app/models/User.js
+++ b/app/models/User.js
@@ -17,6 +17,7 @@ var userSchema = new mongoose.Schema({
   history: Boolean,
   live: Boolean,
   tags: Boolean,
+  pruned: Boolean,
   profile: {
     name: { type: String, default: '' },
     gender: { type: String, default: '' },

--- a/app/public/js/historical.js
+++ b/app/public/js/historical.js
@@ -7,7 +7,7 @@ function afterSetExtremes() {
     var piechart = $('#PIECHART').highcharts();
     var e = chart.xAxis[0].getExtremes();
     chart.showLoading('Loading data from server...');
-//    $('#progressmodel').modal('show');
+    $('#progressmodel').modal('show');
     $.getJSON('/historicalspo2data?start=' + Math.round(e.min) +
         '&end=' + Math.round(e.max), function (data) {
 
@@ -17,22 +17,22 @@ function afterSetExtremes() {
             chart.series[3].setData(data.bpm);
             chart.series[4].setData(data.pi);
             chart.hideLoading();
-//            $('#progressmodel').modal('hide');
+            $('#progressmodel').modal('hide');
         });
-
+        
          $.getJSON('/SPO2Count?start=' + Math.round(e.min) +
         '&end=' + Math.round(e.max), function (data) {
                 piechart.series[0].setData(data);
         });
-
+        
 }
 
 
 $(document).ready(function () {
     $('#progressmodel').modal('toggle');
-
-
-
+    
+  
+    
     $('#PIECHART').highcharts({
         chart: {
             plotBorderWidth: 0,
@@ -47,7 +47,7 @@ $(document).ready(function () {
         },
         plotOptions: {
             pie: {
-
+                
                 startAngle: -90,
                 endAngle: 90,
                 center: ['50%', '75%']
@@ -56,12 +56,12 @@ $(document).ready(function () {
         series: [{
             type: 'pie',
             name: 'O2',
-
+            
         }]
     });
-
-
-
+    
+    
+    
     $.getJSON('/historicalspo2data', function (data) {
 
         $('#MAINGRAPH').highcharts('StockChart', {
@@ -172,9 +172,8 @@ $(document).ready(function () {
                     visible: false
                 }]
         });
-    $('#progressmodel').modal('show');
         afterSetExtremes();
     $('#progressmodel').modal('hide');
-
+        
     });
 });

--- a/app/public/js/historical.js
+++ b/app/public/js/historical.js
@@ -7,7 +7,7 @@ function afterSetExtremes() {
     var piechart = $('#PIECHART').highcharts();
     var e = chart.xAxis[0].getExtremes();
     chart.showLoading('Loading data from server...');
-    $('#progressmodel').modal('show');
+
     $.getJSON('/historicalspo2data?start=' + Math.round(e.min) +
         '&end=' + Math.round(e.max), function (data) {
 
@@ -17,22 +17,24 @@ function afterSetExtremes() {
             chart.series[3].setData(data.bpm);
             chart.series[4].setData(data.pi);
             chart.hideLoading();
-            $('#progressmodel').modal('hide');
+
         });
-        
+
+  piechart.showLoading('Loading pie data from server...');
          $.getJSON('/SPO2Count?start=' + Math.round(e.min) +
         '&end=' + Math.round(e.max), function (data) {
                 piechart.series[0].setData(data);
+                piechart.hideLoading();
         });
-        
+
 }
 
 
 $(document).ready(function () {
-    $('#progressmodel').modal('toggle');
-    
-  
-    
+
+
+
+
     $('#PIECHART').highcharts({
         chart: {
             plotBorderWidth: 0,
@@ -47,7 +49,7 @@ $(document).ready(function () {
         },
         plotOptions: {
             pie: {
-                
+
                 startAngle: -90,
                 endAngle: 90,
                 center: ['50%', '75%']
@@ -56,12 +58,12 @@ $(document).ready(function () {
         series: [{
             type: 'pie',
             name: 'O2',
-            
+
         }]
     });
-    
-    
-    
+
+
+
     $.getJSON('/historicalspo2data', function (data) {
 
         $('#MAINGRAPH').highcharts('StockChart', {
@@ -69,7 +71,14 @@ $(document).ready(function () {
             chart: {
                 zoomType: 'x'
             },
-
+            loading: {
+                style: {
+                    backgroundColor: 'silver'
+                },
+                labelStyle: {
+                    color: 'black'
+                }
+            },
             navigator: {
                 adaptToUpdatedData: false,
                 series: {
@@ -173,7 +182,7 @@ $(document).ready(function () {
                 }]
         });
         afterSetExtremes();
-    $('#progressmodel').modal('hide');
-        
+
+
     });
 });

--- a/app/public/js/historical.js
+++ b/app/public/js/historical.js
@@ -7,7 +7,7 @@ function afterSetExtremes() {
     var piechart = $('#PIECHART').highcharts();
     var e = chart.xAxis[0].getExtremes();
     chart.showLoading('Loading data from server...');
-    $('#progressmodel').modal('show');
+//    $('#progressmodel').modal('show');
     $.getJSON('/historicalspo2data?start=' + Math.round(e.min) +
         '&end=' + Math.round(e.max), function (data) {
 
@@ -17,22 +17,22 @@ function afterSetExtremes() {
             chart.series[3].setData(data.bpm);
             chart.series[4].setData(data.pi);
             chart.hideLoading();
-            $('#progressmodel').modal('hide');
+//            $('#progressmodel').modal('hide');
         });
-        
+
          $.getJSON('/SPO2Count?start=' + Math.round(e.min) +
         '&end=' + Math.round(e.max), function (data) {
                 piechart.series[0].setData(data);
         });
-        
+
 }
 
 
 $(document).ready(function () {
     $('#progressmodel').modal('toggle');
-    
-  
-    
+
+
+
     $('#PIECHART').highcharts({
         chart: {
             plotBorderWidth: 0,
@@ -47,7 +47,7 @@ $(document).ready(function () {
         },
         plotOptions: {
             pie: {
-                
+
                 startAngle: -90,
                 endAngle: 90,
                 center: ['50%', '75%']
@@ -56,12 +56,12 @@ $(document).ready(function () {
         series: [{
             type: 'pie',
             name: 'O2',
-            
+
         }]
     });
-    
-    
-    
+
+
+
     $.getJSON('/historicalspo2data', function (data) {
 
         $('#MAINGRAPH').highcharts('StockChart', {
@@ -172,8 +172,9 @@ $(document).ready(function () {
                     visible: false
                 }]
         });
+    $('#progressmodel').modal('show');
         afterSetExtremes();
     $('#progressmodel').modal('hide');
-        
+
     });
 });

--- a/app/public/js/pruned.js
+++ b/app/public/js/pruned.js
@@ -24,11 +24,7 @@ $(document).ready(function () {
                 liveRedraw: false
             },
             title: {
-                text: 'Historical Oxygen Levels'
-            },
-            subtitle: {
-                text: document.ontouchstart === undefined ?
-                    'Click and drag in the plot area to zoom in' : 'Pinch the chart to zoom in'
+                text: 'Oxygen Levels'
             },
             xAxis: {
                 type: 'datetime'
@@ -36,6 +32,30 @@ $(document).ready(function () {
            //,  crosshair: false
 
             },
+
+
+            yAxis: [{
+                          labels: {
+                            align: 'right',
+                            x: -4
+                          },
+                          title: {
+                              text: 'SpO2 & bpm'
+                          }
+                      }, {
+                          labels: {
+                            align: 'left',
+                            x: 8
+                          },
+                          title: {
+                              text: 'P.I.'
+                          },
+                          top: '75%',
+                          height: '25%',
+                          offset: 0
+                      }
+
+                    ],
 
             legend: {
                 enabled: true
@@ -46,6 +66,7 @@ $(document).ready(function () {
                 },
                 columnrange: {
                     pointPadding: -0.25,
+                    minPointLength: 5,
                     dataGrouping: {
                         groupPixelWidth: 50
                     }
@@ -57,6 +78,7 @@ $(document).ready(function () {
 
             tooltip: {
                 valueDecimals: 2
+              //,  split: true
             },
             rangeSelector: {
                 buttons: [
@@ -124,16 +146,23 @@ $(document).ready(function () {
                     id: 'bpm',
                     data: data.bpm,
                     turboThreshold: 0,
+                    pointPlacement: "between",
                     visible: false
-                },
+                }
+                ,
                 {
                     type: 'spline',
+                    yAxis: 1,
                     name: 'PI',
                     id: 'pi',
                     data: data.pi,
                     turboThreshold: 0,
-                    visible: false
-                }]
+                    pointPlacement: "between",
+                    visible: false,
+                    negativeColor: '#FF0000' ,
+                    threshold: 1
+                }
+              ]
         });
 
 

--- a/app/public/js/pruned.js
+++ b/app/public/js/pruned.js
@@ -1,11 +1,4 @@
-dt_start = new Date(Date.UTC(2017, 2 - 1, 18,19, 0, 0, 0));  //20170218 19:00:00
-ms_start=dt_start.getTime();
-ms_end=ms_start+ 17*60*60*1000 ;
-
-
-
 $(document).ready(function () {
-
 
 
     $.getJSON('/SPO2data?start=' + Math.round(ms_start) +
@@ -146,17 +139,29 @@ $(document).ready(function () {
 
     });
 
+
 });
 
+function get_last_avail_day() {
+  // TODO call server to get the last avalaible day in the ddbb
+  dt_start = new Date(Date.UTC(2017, 2 - 1, 18,19, 0, 0, 0));  //20170218 19:00:00
+  ms_start=dt_start.getTime();
+  ms_end=ms_start+ 17*60*60*1000 ;
+  return {
+      start: ms_start,
+      end: ms_end
+  }
+};
+var ms = get_last_avail_day();
 
 function prev_day(){
-  ms_start=ms_start-24*60*60*1000;
-  ms_end=ms_end-24*60*60*1000;
+  ms.start=ms.start-24*60*60*1000;
+  ms.end=ms.end-24*60*60*1000;
   load_day();
   };
 function next_day(){
-  ms_start=ms_start+24*60*60*1000;
-  ms_end=ms_end+24*60*60*1000;
+  ms.start=ms.start+24*60*60*1000;
+  ms.end=ms.end+24*60*60*1000;
   load_day();
   };
 
@@ -164,8 +169,8 @@ function load_day() {
   var chart = $('#MAINGRAPHPRUNED').highcharts();
     chart.showLoading('Loading data from server...');
 
-    $.getJSON('/SPO2data?start=' + Math.round(ms_start) +
-        '&end=' + Math.round(ms_end), function (data)  {
+    $.getJSON('/SPO2data?start=' + Math.round(ms.start) +
+        '&end=' + Math.round(ms.end), function (data)  {
             chart.series[0].setData(data.spo2,false);
             chart.series[1].setData(data.spo2,false);
             chart.series[2].setData(data.alarms,false);

--- a/app/public/js/pruned.js
+++ b/app/public/js/pruned.js
@@ -4,13 +4,13 @@ $(document).ready(function () {
 
  dt_start = new Date(Date.UTC(2017, 2 - 1, 19, 0, 0, 0, 0));  //20170219
  ms_start=dt_start.getTime();
- ms_end=ms_start+ 1*60*60*1000 ;
+ ms_end=ms_start+ 8*60*60*1000 ;
 
 
 
 
 
-    $.getJSON('/historicalspo2data?start=' + Math.round(ms_start) +
+    $.getJSON('/SPO2data?start=' + Math.round(ms_start) +
         '&end=' + Math.round(ms_end), function (data) {
 
         $('#MAINGRAPHPRUNED').highcharts('StockChart', {
@@ -76,7 +76,7 @@ $(document).ready(function () {
                         text: 'All'
                     }
                 ],
-                selected: 1,
+                selected: 0,
                 inputEnabled: true
             },
 

--- a/app/public/js/pruned.js
+++ b/app/public/js/pruned.js
@@ -1,8 +1,8 @@
 $(document).ready(function () {
 
 
-    $.getJSON('/SPO2data?start=' + Math.round(ms_start) +
-        '&end=' + Math.round(ms_end), function (data) {
+    $.getJSON('/SPO2data?start=' + Math.round(ms.start) +
+        '&end=' + Math.round(ms.end), function (data) {
 
         $('#MAINGRAPHPRUNED').highcharts('StockChart', {
 

--- a/app/public/js/pruned.js
+++ b/app/public/js/pruned.js
@@ -1,12 +1,10 @@
+dt_start = new Date(Date.UTC(2017, 2 - 1, 19,19, 0, 0, 0));  //20170219 19:00:00
+ms_start=dt_start.getTime();
+ms_end=ms_start+ 17*60*60*1000 ;
+
 
 
 $(document).ready(function () {
-
- dt_start = new Date(Date.UTC(2017, 2 - 1, 19, 0, 0, 0, 0));  //20170219
- ms_start=dt_start.getTime();
- ms_end=ms_start+ 8*60*60*1000 ;
-
-
 
 
 
@@ -27,10 +25,7 @@ $(document).ready(function () {
                 }
             },
             navigator: {
-                adaptToUpdatedData: false,
-                series: {
-                    data: data.spo2
-                }
+                adaptToUpdatedData: true
             },
             scrollbar: {
                 liveRedraw: false
@@ -58,13 +53,13 @@ $(document).ready(function () {
                 buttons: [
                     {
                         type: 'hour',
-                        count: 6,
-                        text: '6H'
+                        count: 1,
+                        text: '1H'
                     },
                     {
                         type: 'hour',
-                        count: 12,
-                        text: '12H'
+                        count: 2,
+                        text: '2H'
                     },
                     {
                         type: 'day',
@@ -76,7 +71,7 @@ $(document).ready(function () {
                         text: 'All'
                     }
                 ],
-                selected: 0,
+                selected: 3,
                 inputEnabled: true
             },
 
@@ -129,3 +124,34 @@ $(document).ready(function () {
 
     });
 });
+
+
+function prev_day(){
+  ms_start=ms_start-24*60*60*1000;
+  ms_end=ms_end-24*60*60*1000;
+  load_day();
+  };
+function next_day(){
+  ms_start=ms_start+24*60*60*1000;
+  ms_end=ms_end+24*60*60*1000;
+  load_day();
+  };
+
+function load_day() {
+  var chart = $('#MAINGRAPHPRUNED').highcharts();
+    chart.showLoading('Loading data from server...');
+
+    $.getJSON('/SPO2data?start=' + Math.round(ms_start) +
+        '&end=' + Math.round(ms_end), function (data)  {
+            chart.series[0].setData(data.spo2);
+            chart.series[1].setData(data.spo2);
+            chart.series[2].setData(data.alarms);
+            chart.series[3].setData(data.bpm);
+            chart.series[4].setData(data.pi);
+
+
+            chart.hideLoading();
+            chart.rangeSelector.clickButton(3, true);
+
+        });
+}

--- a/app/public/js/pruned.js
+++ b/app/public/js/pruned.js
@@ -1,0 +1,131 @@
+
+
+$(document).ready(function () {
+
+ dt_start = new Date(Date.UTC(2017, 2 - 1, 19, 0, 0, 0, 0));  //20170219
+ ms_start=dt_start.getTime();
+ ms_end=ms_start+ 1*60*60*1000 ;
+
+
+
+
+
+    $.getJSON('/historicalspo2data?start=' + Math.round(ms_start) +
+        '&end=' + Math.round(ms_end), function (data) {
+
+        $('#MAINGRAPHPRUNED').highcharts('StockChart', {
+
+            chart: {
+                zoomType: 'x'
+            },
+            loading: {
+                style: {
+                    backgroundColor: 'silver'
+                },
+                labelStyle: {
+                    color: 'black'
+                }
+            },
+            navigator: {
+                adaptToUpdatedData: false,
+                series: {
+                    data: data.spo2
+                }
+            },
+            scrollbar: {
+                liveRedraw: false
+            },
+            title: {
+                text: 'Historical Oxygen Levels'
+            },
+            subtitle: {
+                text: document.ontouchstart === undefined ?
+                    'Click and drag in the plot area to zoom in' : 'Pinch the chart to zoom in'
+            },
+            xAxis: {
+                type: 'datetime'
+            },
+
+            legend: {
+                enabled: true
+            },
+            plotOptions: {
+                line: {
+                    connectNulls: false
+                }
+            },
+            rangeSelector: {
+                buttons: [
+                    {
+                        type: 'hour',
+                        count: 6,
+                        text: '6H'
+                    },
+                    {
+                        type: 'hour',
+                        count: 12,
+                        text: '12H'
+                    },
+                    {
+                        type: 'day',
+                        count: 1,
+                        text: '1D'
+                    },
+                    {
+                        type: 'all',
+                        text: 'All'
+                    }
+                ],
+                selected: 1,
+                inputEnabled: true
+            },
+
+            series: [
+                {
+                    type: 'columnrange',
+                    name: 'O2%',
+                    data: data.spo2,
+                    turboThreshold: 0
+                },
+                {
+                    type: 'spline',
+                    name: 'O2%',
+                    id: 'spo2',
+                    data: data.spo2,
+                    turboThreshold: 0
+                },
+                {
+                    type: 'scatter',
+                    name: 'Alarm',
+                    color: "rgba(178,34,34,0.5)",
+                    fillColor: 'rgba(178,34,34,0.5)',
+                    data: data.alarms,
+                    onSeries: 'spo2',
+                    turboThreshold: 0,
+                    showInLegend: false,
+                    tooltip: {
+                        headerFormat: '<b>{series.name}</b><br>',
+                        pointFormat: ('{point.y} O2%</br>{point.bpm} BPM</br>{point.pi} PI')
+                    }
+                },
+                {
+                    type: 'spline',
+                    name: 'BPM',
+                    id: 'bpm',
+                    data: data.bpm,
+                    turboThreshold: 0,
+                    visible: false
+                },
+                {
+                    type: 'spline',
+                    name: 'PI',
+                    id: 'pi',
+                    data: data.pi,
+                    turboThreshold: 0,
+                    visible: false
+                }]
+        });
+
+
+    });
+});

--- a/app/public/js/pruned.js
+++ b/app/public/js/pruned.js
@@ -1,4 +1,4 @@
-dt_start = new Date(Date.UTC(2017, 2 - 1, 19,19, 0, 0, 0));  //20170219 19:00:00
+dt_start = new Date(Date.UTC(2017, 2 - 1, 18,19, 0, 0, 0));  //20170218 19:00:00
 ms_start=dt_start.getTime();
 ms_end=ms_start+ 17*60*60*1000 ;
 
@@ -39,6 +39,9 @@ $(document).ready(function () {
             },
             xAxis: {
                 type: 'datetime'
+
+           //,  crosshair: false
+
             },
 
             legend: {
@@ -47,24 +50,37 @@ $(document).ready(function () {
             plotOptions: {
                 line: {
                     connectNulls: false
-                }
+                },
+                columnrange: {
+                    pointPadding: -0.25,
+                    dataGrouping: {
+                        groupPixelWidth: 50
+                    }
+                  }
+            },
+
+
+
+
+            tooltip: {
+                valueDecimals: 2
             },
             rangeSelector: {
                 buttons: [
                     {
+                        type: 'minute',
+                        count: 1,
+                        text: '1M'
+                    },
+                    {
+                        type: 'minute',
+                        count: 10,
+                        text: '10M'
+                    },
+                    {
                         type: 'hour',
                         count: 1,
                         text: '1H'
-                    },
-                    {
-                        type: 'hour',
-                        count: 2,
-                        text: '2H'
-                    },
-                    {
-                        type: 'day',
-                        count: 1,
-                        text: '1D'
                     },
                     {
                         type: 'all',
@@ -80,14 +96,16 @@ $(document).ready(function () {
                     type: 'columnrange',
                     name: 'O2%',
                     data: data.spo2,
-                    turboThreshold: 0
+                    turboThreshold: 0,
+                    pointPlacement: "between"
                 },
                 {
                     type: 'spline',
                     name: 'O2%',
                     id: 'spo2',
                     data: data.spo2,
-                    turboThreshold: 0
+                    turboThreshold: 0,
+                    pointPlacement: "between"
                 },
                 {
                     type: 'scatter',
@@ -97,11 +115,15 @@ $(document).ready(function () {
                     data: data.alarms,
                     onSeries: 'spo2',
                     turboThreshold: 0,
-                    showInLegend: false,
-                    tooltip: {
-                        headerFormat: '<b>{series.name}</b><br>',
-                        pointFormat: ('{point.y} O2%</br>{point.bpm} BPM</br>{point.pi} PI')
-                    }
+                    showInLegend: true
+                    // tooltip: {
+                    //     headerFormat: '<b>{series.name}</b><br>',
+                    //     pointFormat: ('{point.y} O2%</br>{point.bpm} BPM</br>{point.pi} PI')
+                    // },
+                    // dataGrouping: {
+                    //     forced: true,
+                    //     smoothed: false
+                    // }
                 },
                 {
                     type: 'spline',
@@ -123,6 +145,7 @@ $(document).ready(function () {
 
 
     });
+
 });
 
 
@@ -143,11 +166,13 @@ function load_day() {
 
     $.getJSON('/SPO2data?start=' + Math.round(ms_start) +
         '&end=' + Math.round(ms_end), function (data)  {
-            chart.series[0].setData(data.spo2);
-            chart.series[1].setData(data.spo2);
-            chart.series[2].setData(data.alarms);
-            chart.series[3].setData(data.bpm);
-            chart.series[4].setData(data.pi);
+            chart.series[0].setData(data.spo2,false);
+            chart.series[1].setData(data.spo2,false);
+            chart.series[2].setData(data.alarms,false);
+            chart.series[3].setData(data.bpm,false);
+            chart.series[4].setData(data.pi,false);
+
+            chart.redraw();
 
 
             chart.hideLoading();

--- a/app/views/admin/accounts.jade
+++ b/app/views/admin/accounts.jade
@@ -14,6 +14,7 @@ block content
                 th History
                 th Live
                 th Tags
+                th Pruned
         tbody
             each val in users
                 tr
@@ -30,6 +31,8 @@ block content
                         input(type='checkbox',name='live', checked=val.live onchange='updateRights("#{val.id}", "live",  this.checked);' )
                     td
                         input(type='checkbox',name='tags', checked=val.live onchange='updateRights("#{val.id}", "tags",  this.checked);' )
+                    td
+                        input(type='checkbox',name='pruned', checked=val.live onchange='updateRights("#{val.id}", "pruned",  this.checked);' )
 
 
 block scripts

--- a/app/views/historical.jade
+++ b/app/views/historical.jade
@@ -2,7 +2,7 @@ extends layout
 
 block content
   p.lead Graphs
-  hr      
+  hr
   .row
     .col-sm-12
       #MAINGRAPH(style='min-width: 310px; height: 600px; margin: 0 auto')
@@ -10,11 +10,11 @@ block content
     .col-md-12
       p.text-center
         small you can click on the legend names (O2, BPM, PI) at the bottom of the graph to turn on and off different results
-  hr      
+  hr
   .row
     .col-sm-12
       #PIECHART(style='min-width: 310px; height: 600px; margin: 0 auto')
-          
+
 
   .modal.fade(tabindex='-1', role='dialog', id="progressmodel")
     .modal-dialog.modal-vertical-centered
@@ -27,5 +27,6 @@ block content
 block scripts
     script(src='https://code.highcharts.com/stock/highstock.js')
     script(src='https://code.highcharts.com/stock/highcharts-more.js')
+    script(src='https://code.highcharts.com/modules/no-data-to-display.js')
     script(src='/js/theme.js')
     script(src='/js/historical.js')

--- a/app/views/home.jade
+++ b/app/views/home.jade
@@ -27,6 +27,13 @@ block content
                     p Adding qualitative info on how #{theme.babyname} slept tonight.
                     p
                         a.btn.btn-primary(href='/tags', role='button') Open Tags tab »
+        if user.pruned
+            .row
+                .col-sm-6
+                    h2 Pruned
+                    p Pruned historical data so that the client cache can handle it.
+                    p
+                    a.btn.btn-primary(href='/pruned', role='button') Open Pruned tab »
         if !user.history && !user.admin && !user.live && !user.tags
             .row
                 .col-sm-6

--- a/app/views/partials/header.jade
+++ b/app/views/partials/header.jade
@@ -23,6 +23,9 @@
             if user.tags
                 li(class=title=='Tags'?'active':undefined)
                     a(href='/tags') Tags
+            if user.pruned
+                li(class=title=='Pruned'?'active':undefined)
+                    a(href='/pruned') Pruned
             if user.admin
                 li(class=title=='Admin'?'active':undefined)
                     a(href='/admin') Admin

--- a/app/views/pruned.jade
+++ b/app/views/pruned.jade
@@ -10,9 +10,10 @@ block content
     .col-md-12
       p.text-center
         small you can click on the legend names (O2, BPM, PI) at the bottom of the graph to turn on and off different results
-
-
-
+  .row
+  .col-md-12
+   a.btn.btn-primary(onclick='prev_day()') Prev. Day
+   a.btn.btn-primary(onclick='next_day()') Next Day
 
 block scripts
     script(src='https://code.highcharts.com/stock/highstock.js')

--- a/app/views/pruned.jade
+++ b/app/views/pruned.jade
@@ -2,8 +2,20 @@ extends layout
 
 block content
   p.lead Pruned view
+  hr
+  .row
+    .col-sm-12
+      #MAINGRAPHPRUNED(style='min-width: 310px; height: 600px; margin: 0 auto')
+  .row
+    .col-md-12
+      p.text-center
+        small you can click on the legend names (O2, BPM, PI) at the bottom of the graph to turn on and off different results
+
+
+
 
 block scripts
+    script(src='https://code.highcharts.com/stock/highstock.js')
+    script(src='https://code.highcharts.com/stock/highcharts-more.js')
     script(src='/js/theme.js')
-    script(src='/js/main.js')
-    script(src='/js/tag.js')
+    script(src='/js/pruned.js')

--- a/app/views/pruned.jade
+++ b/app/views/pruned.jade
@@ -1,0 +1,9 @@
+extends layout
+
+block content
+  p.lead Pruned view
+
+block scripts
+    script(src='/js/theme.js')
+    script(src='/js/main.js')
+    script(src='/js/tag.js')

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -8,6 +8,8 @@ import serial
 import Devices.RAD8
 import Devices.RAD7
 
+from datetime import datetime
+
 def read_and_parse_monitor_data():
     "Read from Serial port and parse depending on what device is selected"
     #config
@@ -37,7 +39,7 @@ def read_and_parse_monitor_data():
     while 1:
 	#read from Serial
         device_output = serial_connection.readline()
-        print device_output
+        print ('%s  -->%s' % (str(datetime.now()),device_output))
         try:
             event = None
             if device_type == "RAD8":

--- a/scripts/monitor.py
+++ b/scripts/monitor.py
@@ -8,8 +8,6 @@ import serial
 import Devices.RAD8
 import Devices.RAD7
 
-from datetime import datetime
-
 def read_and_parse_monitor_data():
     "Read from Serial port and parse depending on what device is selected"
     #config
@@ -39,7 +37,7 @@ def read_and_parse_monitor_data():
     while 1:
 	#read from Serial
         device_output = serial_connection.readline()
-        print ('%s  -->%s' % (str(datetime.now()),device_output))
+        print device_output
         try:
             event = None
             if device_type == "RAD8":


### PR DESCRIPTION
We open this pull request so that you can take a look already at what we are trying to do.

We've added a new view that we call "pruned". This shows the historical data but only for one day. (Note that right now it shows a fixed day, but the purpose is to show the last day available). This way, all the points of the graph can be saved into the browser, and the zoom in's, out's and stuff to figure out how it went last night go very fast.

We would also like to implement some other features, in addition to the current buttons to navigate forward and backwards 1 day, such as:
- navigate in a calendar
- save some days for future reference/analysis

On the other hand, besides this new view, we've solved some minor issues:
- corrections on a couple of issues in the historical view in [53bdb83](https://github.com/lrnzcig/Baby-Monitor-Masimo-Pulse-Oximeter/commit/53bdb833bbfed96b8d56ab458bc35948da661885) (besides we've removed the modal window in [0641c8d](https://github.com/lrnzcig/Baby-Monitor-Masimo-Pulse-Oximeter/commit/0641c8d887a11bb7de07bc1223d63093e5c4743f))
- reconnect to MongoDB if the connection is lost
- logging in the python code for the device

Please let us know your opinion on these changes. In the following weeks, we'll try to get the "pruned" view more complete.

Thanks in advance!!